### PR TITLE
Optimisation BLE, lecture FSL et Filtrage des données

### DIFF
--- a/ArduinoSort.h
+++ b/ArduinoSort.h
@@ -1,0 +1,61 @@
+#ifndef ArduinoSort_h
+#define ArduinoSort_h
+
+/**** These are the functions you can use ****/
+
+// Sort an array
+template<typename AnyType> void sortArray(AnyType array[], size_t sizeOfArray);
+
+// Sort in reverse
+template<typename AnyType> void sortArrayReverse(AnyType array[], size_t sizeOfArray);
+
+// Sort an array with custom comparison function
+template<typename AnyType> void sortArray(AnyType array[], size_t sizeOfArray, bool (*largerThan)(AnyType, AnyType));
+
+// Sort in reverse with custom comparison function
+template<typename AnyType> void sortArrayReverse(AnyType array[], size_t sizeOfArray, bool (*largerThan)(AnyType, AnyType));
+
+
+
+
+
+/**** Implementation below. Do not use below functions ****/
+
+namespace ArduinoSort {
+	template<typename AnyType> bool builtinLargerThan(AnyType first, AnyType second) {
+		return first > second;
+	}
+
+	template<> bool builtinLargerThan(char* first, char* second) {
+		return strcmp(first, second) > 0;
+	}
+
+	template<typename AnyType> void insertionSort(AnyType array[], size_t sizeOfArray, bool reverse, bool (*largerThan)(AnyType, AnyType)) {
+		for (size_t i = 1; i < sizeOfArray; i++) {
+			for (size_t j = i; j > 0 && (largerThan(array[j-1], array[j]) != reverse); j--) {
+				AnyType tmp = array[j-1];
+				array[j-1] = array[j];
+				array[j] = tmp;
+			}
+		}
+	}
+}
+
+template<typename AnyType> void sortArray(AnyType array[], size_t sizeOfArray) {
+	ArduinoSort::insertionSort(array, sizeOfArray, false, ArduinoSort::builtinLargerThan);
+}
+
+template<typename AnyType> void sortArrayReverse(AnyType array[], size_t sizeOfArray) {
+	ArduinoSort::insertionSort(array, sizeOfArray, true, ArduinoSort::builtinLargerThan);
+}
+
+template<typename AnyType> void sortArray(AnyType array[], size_t sizeOfArray, bool (*largerThan)(AnyType, AnyType)) {
+	ArduinoSort::insertionSort(array, sizeOfArray, false, largerThan);
+}
+
+template<typename AnyType> void sortArrayReverse(AnyType array[], size_t sizeOfArray, bool (*largerThan)(AnyType, AnyType)) {
+	ArduinoSort::insertionSort(array, sizeOfArray, true, largerThan);
+}
+
+
+#endif

--- a/LimiTTer-ESP32.ino
+++ b/LimiTTer-ESP32.ino
@@ -516,12 +516,14 @@ void Send_Packet(String packet) {
         int Packet_Size = packet.length() + 1;
         char BlePacket[Packet_Size];
         packet.toCharArray(BlePacket, Packet_Size);
+        delay(100); // small delay before sending first packet
         pTxCharacteristic->setValue(BlePacket);
         pTxCharacteristic->notify();  
-        delay(10);
         Serial.println("Packet sent : " + packet);
+        delay(1000); // Send packet twice to avoid missing packet
         pTxCharacteristic->setValue(BlePacket);
         pTxCharacteristic->notify();  
+        Serial.println("Packet sent : " + packet);
       } else {
         Serial.println("Pb BLE connection, Packet not sent : " + packet);
       }


### PR DESCRIPTION
Optimisation du Bluetooth et de la conso : 
- Initialisation LE juste après le boot
- Alimentation BM019 puis lecture FSL
- Coupure de l'alim BM019
- Boucle de vérification de la connexion BLE avant envoi 2 fois du packet (2 fois car il arrive que le 1er packet ne soit pas reçu par le téléphone…)
Optimisation de la lecture et du filtrage des données
- Lecture directe de la mémoire du FSL sans passer par la double convertion Octet => Char => Raw value
- Lecture complète de toutes les valeurs (16 dernières minutes et 8 dernières heures)
- Amélioration du filtrage par un 1er calcul de la droite des moindres carré sur les 16 dernières minutes, 
- l'exclusion des 5 points dont l'écart type avec la droite est maximal (je me suis rendu compte qu'on pouvait avoir des irrégularités successives sur 3 ou 4 minutes successives)
- nouveau calcul de droite des moindres carrés sur les 11 points restants
- renvoi en Bluetooth la valeur correspondante à la dernière valeur lue, mais positionnée sur cette 2ème droite des moindres carrés.
